### PR TITLE
Fixed a build bug on Win64

### DIFF
--- a/exlib/include/utils.h
+++ b/exlib/include/utils.h
@@ -13,7 +13,7 @@
 #include "osconfig.h"
 #include <atomic>
 
-#ifdef WIN32
+#ifdef Windows
 #include "utils_win.h"
 #elif defined(amd64)
 #include "utils_x64.h"


### PR DESCRIPTION
The utils_win.h should still be included on for Windows build no matter it is x86 or x64 as the utils_win.h has implementations for both. Instead the impl from the utils_x64.h does not compile in Visual Studio.