### PR TITLE
build, refactor: re-support clang on Windows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - 'dev'
       - 'master'
       - 'test_ci'
+      - 'feat/**'
     tags:
       - v0.*.*
       - v1.*.*
@@ -62,85 +63,7 @@ jobs:
         id: set-env-vars
         shell: bash
         run: |
-          . ./scripts/get_env.sh --source-only
-          get_build_env;
-          echo "::set-output name=TARGET_OS::$TARGET_OS"
-
-          export GIT_BRANCH=${GITHUB_REF#refs/heads/}
-          echo "::set-output name=GIT_BRANCH::$GIT_BRANCH"
-          export GIT_COMMIT_HEAD_MSG=$(git log --format=%b -1)
-          echo "::set-output name=GIT_COMMIT_HEAD_MSG::$GIT_COMMIT_HEAD_MSG"
-          export GIT_COMMIT_SHORTCUTS=$(git log --format=%h -1)
-          echo "::set-output name=GIT_COMMIT_SHORTCUTS::$GIT_COMMIT_SHORTCUTS"
-          export GIT_COMMIT_TIME=$(git show -s --format="%cd" --date=format:%Y%m%d%H%M%S HEAD)
-          echo "::set-output name=GIT_COMMIT_TIME::$GIT_COMMIT_TIME"
-
-          if [ "$GITHUB_REPOSITORY" == "fibjs/fibjs_vender" ]; then
-            export IS_MAIN_REPO=1
-          fi
-          if [[ -z "$IS_MAIN_REPO" || "$GIT_BRANCH" == "dev" ]]; then
-            echo "::set-output name=IS_UPLOAD_ASSETS::1"
-          fi
-          
-          export RELEASE_TAG="$GIT_COMMIT_TIME-$GIT_COMMIT_SHORTCUTS";
-          if [ -z "$IS_MAIN_REPO" ]; then
-            SUFFIX=${GIT_BRANCH//'/'/'-'}
-            RELEASE_TAG="$RELEASE_TAG-$SUFFIX"
-          fi
-          echo "::set-output name=RELEASE_TAG::$RELEASE_TAG"
-
-          git fetch;
-          if [ $(git tag --list | egrep "^$RELEASE_TAG$") ]; then
-            echo "tag $RELEASE_TAG existed";
-            export TAG_EXISTED="YES"
-          else
-            export TAG_EXISTED=""
-          fi
-          echo "::set-output name=TAG_EXISTED::$TAG_EXISTED"
-
-          case "${TARGET_ARCH}" in
-            i386)
-              DIST_ARCH=x86
-              SNAPSHOT_ARCH=ia32
-                ;;
-            amd64)
-              DIST_ARCH=x64
-              SNAPSHOT_ARCH=x64
-                ;;
-            *)
-              DIST_ARCH=$TARGET_ARCH
-              SNAPSHOT_ARCH=$TARGET_ARCH
-              ;;
-          esac
-
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            export TARGET_OS_NAME="Linux";
-            export DIST_FILE="vender-linux-${DIST_ARCH}-$BUILD_TYPE.zip"
-            export DIST_DIR="${TARGET_OS_NAME}_${TARGET_ARCH}_$BUILD_TYPE"
-            export SNAPSHOT_FNAME="snapshot-$SNAPSHOT_ARCH-Linux.cc"
-          fi
-
-          if [[ "$RUNNER_OS" == "macOS" ]]; then
-            export TARGET_OS_NAME="Darwin";
-            export DIST_FILE="vender-darwin-${DIST_ARCH}-$BUILD_TYPE.zip"
-            export DIST_DIR="${TARGET_OS_NAME}_${TARGET_ARCH}_$BUILD_TYPE"
-            export SNAPSHOT_FNAME="snapshot-$SNAPSHOT_ARCH-Darwin.cc"
-          fi
-
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            export TARGET_OS_NAME="Windows";
-            export DIST_FILE="vender-windows-${DIST_ARCH}-$BUILD_TYPE.zip"
-            export DIST_DIR="${TARGET_OS_NAME}_${TARGET_ARCH}_$BUILD_TYPE"
-            export SNAPSHOT_FNAME="snapshot-$SNAPSHOT_ARCH-Windows.cc"
-          fi
-
-          echo "::set-output name=TARGET_OS_NAME::$TARGET_OS_NAME"
-          echo "::set-output name=DIST_FILE::$DIST_FILE"
-          echo "::set-output name=DIST_DIR::$DIST_DIR"
-          echo "::set-output name=SNAPSHOT_FNAME::$SNAPSHOT_FNAME"
-
-          export DIST_FILEPATH=$RELEASE_TAG/$DIST_FILE
-          echo "::set-output name=DIST_FILEPATH::$DIST_FILEPATH"
+          bash .github/workflows/set-env-vars.sh
         env:
           TARGET_ARCH: ${{ matrix.target_arch }}
           BUILD_TYPE: ${{ matrix.build_type }}

--- a/.github/workflows/set-env-vars.sh
+++ b/.github/workflows/set-env-vars.sh
@@ -1,0 +1,79 @@
+. ./scripts/get_env.sh --source-only
+get_build_env;
+echo "::set-output name=TARGET_OS::$TARGET_OS"
+
+export GIT_BRANCH=${GITHUB_REF#refs/heads/}
+echo "::set-output name=GIT_BRANCH::$GIT_BRANCH"
+export GIT_COMMIT_HEAD_MSG=$(git log --format=%b -1)
+echo "::set-output name=GIT_COMMIT_HEAD_MSG::$GIT_COMMIT_HEAD_MSG"
+export GIT_COMMIT_SHORTCUTS=$(git log --format=%h -1)
+echo "::set-output name=GIT_COMMIT_SHORTCUTS::$GIT_COMMIT_SHORTCUTS"
+export GIT_COMMIT_TIME=$(git show -s --format="%cd" --date=format:%Y%m%d%H%M%S HEAD)
+echo "::set-output name=GIT_COMMIT_TIME::$GIT_COMMIT_TIME"
+
+if [ "$GITHUB_REPOSITORY" == "fibjs/fibjs_vender" ]; then
+    export IS_MAIN_REPO=1
+fi
+if [[ -z "$IS_MAIN_REPO" || "$GIT_BRANCH" == "dev" ]]; then
+    echo "::set-output name=IS_UPLOAD_ASSETS::1"
+fi
+
+export RELEASE_TAG="$GIT_COMMIT_TIME-$GIT_COMMIT_SHORTCUTS";
+if [ -z "$IS_MAIN_REPO" ]; then
+    SUFFIX=${GIT_BRANCH//\//'-'}
+    RELEASE_TAG="$RELEASE_TAG-$SUFFIX"
+fi
+echo "::set-output name=RELEASE_TAG::$RELEASE_TAG"
+
+git fetch;
+if [ $(git tag --list | egrep "^$RELEASE_TAG$") ]; then
+    echo "tag $RELEASE_TAG existed";
+    export TAG_EXISTED="YES"
+else
+    export TAG_EXISTED=""
+fi
+echo "::set-output name=TAG_EXISTED::$TAG_EXISTED"
+
+case "${TARGET_ARCH}" in
+    i386)
+        DIST_ARCH=x86
+        SNAPSHOT_ARCH=ia32
+        ;;
+    amd64)
+        DIST_ARCH=x64
+        SNAPSHOT_ARCH=x64
+        ;;
+    *)
+        DIST_ARCH=$TARGET_ARCH
+        SNAPSHOT_ARCH=$TARGET_ARCH
+        ;;
+esac
+
+if [[ "$RUNNER_OS" == "Linux" ]]; then
+    export TARGET_OS_NAME="Linux";
+    export DIST_FILE="vender-linux-${DIST_ARCH}-$BUILD_TYPE.zip"
+    export DIST_DIR="${TARGET_OS_NAME}_${TARGET_ARCH}_$BUILD_TYPE"
+    export SNAPSHOT_FNAME="snapshot-$SNAPSHOT_ARCH-Linux.cc"
+fi
+
+if [[ "$RUNNER_OS" == "macOS" ]]; then
+    export TARGET_OS_NAME="Darwin";
+    export DIST_FILE="vender-darwin-${DIST_ARCH}-$BUILD_TYPE.zip"
+    export DIST_DIR="${TARGET_OS_NAME}_${TARGET_ARCH}_$BUILD_TYPE"
+    export SNAPSHOT_FNAME="snapshot-$SNAPSHOT_ARCH-Darwin.cc"
+fi
+
+if [[ "$RUNNER_OS" == "Windows" ]]; then
+    export TARGET_OS_NAME="Windows";
+    export DIST_FILE="vender-windows-${DIST_ARCH}-$BUILD_TYPE.zip"
+    export DIST_DIR="${TARGET_OS_NAME}_${TARGET_ARCH}_$BUILD_TYPE"
+    export SNAPSHOT_FNAME="snapshot-$SNAPSHOT_ARCH-Windows.cc"
+fi
+
+echo "::set-output name=TARGET_OS_NAME::$TARGET_OS_NAME"
+echo "::set-output name=DIST_FILE::$DIST_FILE"
+echo "::set-output name=DIST_DIR::$DIST_DIR"
+echo "::set-output name=SNAPSHOT_FNAME::$SNAPSHOT_FNAME"
+
+export DIST_FILEPATH=$RELEASE_TAG/$DIST_FILE
+echo "::set-output name=DIST_FILEPATH::$DIST_FILEPATH"

--- a/build
+++ b/build
@@ -17,6 +17,8 @@ usage()
 	echo "      Print this message and exit."
 	echo "  -j: enable make '-j' option."
 	echo "      if 'n' is not given, will set jobs to auto detected core count, otherwise n is used."
+	echo "  --use-clang:"
+	echo "      Force use clang on Windows."
 	echo ""
 }
 
@@ -36,6 +38,9 @@ do
         --help|-h) usage
             exit 1
             ;;
+        --use-clang)
+            BUILD_USE_CLANG="true"
+            ;;
         *) echo "illegal option $i"
             usage
             exit 1
@@ -47,4 +52,5 @@ cmake -DBUILD_ARCH=${BUILD_ARCH}\
     -DBUILD_TYPE=${BUILD_TYPE}\
     -DCLEAN_BUILD=${CLEAN_BUILD}\
     -DBUILD_JOBS=${BUILD_JOBS}\
+    -DBUILD_USE_CLANG=${BUILD_USE_CLANG}\
     -P build.cmake

--- a/build.cmd
+++ b/build.cmd
@@ -27,8 +27,13 @@ for %%a in (%*) do (
         set ARG_ERROR=no
     )
 
+    if "%%a"=="--use-clang" (
+    	set BUILD_USE_CLANG=true
+        set ARG_ERROR=no
+    )
+
     if "%%a"=="clean" (
-    	set BUILD_TYPE=clean
+    	set CLEAN_BUILD=true
         set ARG_ERROR=no
     )
 
@@ -41,7 +46,7 @@ for %%a in (%*) do (
     )
 )
 
-cmake -DBUILD_ARCH=%BUILD_ARCH% -DBUILD_TYPE=%BUILD_TYPE% -DBUILD_JOBS=%BUILD_JOBS% -P build.cmake
+cmake -DBUILD_ARCH=%BUILD_ARCH% -DBUILD_TYPE=%BUILD_TYPE% -DBUILD_JOBS=%BUILD_JOBS% -DCLEAN_BUILD=%CLEAN_BUILD% -DBUILD_USE_CLANG=%BUILD_USE_CLANG% -P build.cmake
 
 goto finished
 
@@ -61,6 +66,8 @@ goto finished
 	echo       Print this message and exit.
 	echo   -j: enable make '-j' option.
 	echo       if 'n' is not given, will set jobs to auto detected core count, otherwise n is used.
+	echo   --use-clang:
+	echo       Force use clang on Windows.
 	echo.
     exit /B 1
 

--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -1,3 +1,7 @@
 cmake_minimum_required(VERSION 2.6)
 
+if((${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows") AND (NOT MSVC))
+    set(flags "-fexceptions")
+endif()
+
 include(../tools/Library.cmake)

--- a/tools/Library.cmake
+++ b/tools/Library.cmake
@@ -12,4 +12,4 @@ set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/../../../bin/${CMAKE_HOST_SYSTEM_N
 
 include_directories(${PROJECT_SOURCE_DIR} "${PROJECT_SOURCE_DIR}/include" "${PROJECT_SOURCE_DIR}/../")
 
-link_libraries(${name})
+setup_result_library(${name})

--- a/tools/LibraryTest.cmake
+++ b/tools/LibraryTest.cmake
@@ -1,6 +1,7 @@
 get_filename_component(src ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
 get_filename_component(libname ${src} NAME)
 set(name "${libname}_test")
+
 project(${name})
 
 include(${CMAKE_CURRENT_LIST_DIR}/option.cmake)
@@ -17,7 +18,7 @@ foreach(lib ${libs})
 	target_link_libraries(${name} "${EXECUTABLE_OUTPUT_PATH}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib}${CMAKE_STATIC_LIBRARY_SUFFIX}")
 endforeach()
 
-link_libraries(${name})
+setup_result_library(${name})
 
 if(link_flags)
 	set_target_properties(${name} PROPERTIES LINK_FLAGS ${link_flags})

--- a/tools/option_flags.cmake
+++ b/tools/option_flags.cmake
@@ -1,4 +1,3 @@
-
 # get host's architecture in cmake script mode
 function(gethostarch RETVAL)
     if("${${RETVAL}}" STREQUAL "")
@@ -50,10 +49,10 @@ if(NOT DEFINED link_flags)
     set(link_flags "")
 endif()
 
-if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
-    include(${CMAKE_CURRENT_LIST_DIR}/option_flags_vc.cmake)
+if(MSVC)
+	include(${CMAKE_CURRENT_LIST_DIR}/option_flags_vc.cmake)
 else()
-    include(${CMAKE_CURRENT_LIST_DIR}/option_flags_clang.cmake)
+	include(${CMAKE_CURRENT_LIST_DIR}/option_flags_clang.cmake)
 endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flags} ${cflags}")

--- a/tools/option_flags_vc.cmake
+++ b/tools/option_flags_vc.cmake
@@ -1,28 +1,46 @@
+# dirty code for replace compilation options of MSVC
 macro(configure_msvc_runtime)
-	set(variables
-		CMAKE_C_FLAGS
-		CMAKE_C_FLAGS_RELEASE
-		CMAKE_CXX_FLAGS
-		CMAKE_CXX_FLAGS_RELEASE)
+    set(variables
+        CMAKE_C_FLAGS
+        CMAKE_C_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS
+        CMAKE_CXX_FLAGS_RELEASE)
 
-	foreach(variable ${variables})
-		if(${variable} MATCHES "/MD")
-			string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
-			set(${variable} "${${variable}}" CACHE STRING "MSVC_${variable}" FORCE)
-		endif()
-	endforeach()
+    foreach(variable ${variables})
+        if(${variable} MATCHES "/MD")
+            string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
+            set(${variable} "${${variable}}" CACHE STRING "MSVC_${variable}" FORCE)
+        endif()
+    endforeach()
 endmacro()
 
+# keep same name format with Unix
 set(CMAKE_STATIC_LIBRARY_PREFIX "lib")
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_definitions(-DWIN32 -D_LIB -D_CRT_SECURE_NO_WARNINGS -D_CRT_RAND_S -DNOMINMAX -D_FILE_OFFSET_BITS=64)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_compile_options(/MP)
+
+set(link_flags "${link_flags} /OPT:ICF /ERRORREPORT:PROMPT /NOLOGO /TLBID:1")
+
+set(ccflags "${ccflags} -std=c++14")
 
 add_definitions(-DWIN32 -D_LIB -D_CRT_SECURE_NO_WARNINGS -D_CRT_RAND_S -DNOMINMAX)
 
 if(${BUILD_TYPE} STREQUAL "release")
-	add_definitions(-DNDEBUG=1)
 	set(flags "${flags} -W0")
-	configure_msvc_runtime()
+
+    configure_msvc_runtime()
+
+	add_definitions(-DNDEBUG=1)
 elseif(${BUILD_TYPE} STREQUAL "debug")
-	add_definitions(-DDEBUG=1)
+	add_definitions(-DDEBUG=1 -D_DEBUG)
 endif()
 
-add_compile_options(/MP)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flags} ${cflags}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flags} ${ccflags}")

--- a/tools/option_libs.cmake
+++ b/tools/option_libs.cmake
@@ -1,4 +1,4 @@
-function(link_libraries name)
+function(setup_result_library name)
     if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
         target_link_libraries(${name} winmm ws2_32 psapi dbghelp shlwapi urlmon
             userenv advapi32 kernel32 iphlpapi)

--- a/uuid/CMakeLists.txt
+++ b/uuid/CMakeLists.txt
@@ -1,3 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 
+if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
+    # @note: there's no __STDC__ definition on git-bash of Windows
+    add_definitions(-D__STDC__)
+endif()
+
 include(../tools/Library.cmake)

--- a/uv/CMakeLists.txt
+++ b/uv/CMakeLists.txt
@@ -43,6 +43,12 @@ set(uv_sources
 	src/version.c)
 
 if(WIN32)
+	list(APPEND uv_defines WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0600)
+	list(APPEND uv_libraries
+		 psapi
+		 iphlpapi
+		 userenv
+		 ws2_32)
 	list(APPEND uv_sources
 		 src/win/async.c
 		 src/win/core.c
@@ -69,8 +75,15 @@ if(WIN32)
 		 src/win/util.c
 		 src/win/winapi.c
 		 src/win/winsock.c)
+	list(APPEND uv_test_libraries ws2_32)
 else()
 	list(APPEND uv_defines _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
+	if(NOT CMAKE_SYSTEM_NAME MATCHES "Android|OS390")
+		# TODO: This should be replaced with find_package(Threads) if possible
+		# Android has pthread as part of its c library, not as a separate
+		# libpthread.so.
+		list(APPEND uv_libraries pthread)
+	endif()
 	list(APPEND uv_sources
 			src/unix/async.c
 			src/unix/core.c
@@ -126,6 +139,7 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   list(APPEND uv_defines _GNU_SOURCE _POSIX_C_SOURCE=200112)
+  list(APPEND uv_libraries dl rt)
   list(APPEND uv_sources
        src/unix/linux-core.c
        src/unix/linux-inotify.c
@@ -141,6 +155,7 @@ set(src_list "${uv_sources}")
 include(../tools/Library.cmake)
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE ${uv_defines})
+target_link_libraries(${PROJECT_NAME} ${uv_libraries})
 
 include_directories(
 	PUBLIC

--- a/v8/CMakeLists.txt
+++ b/v8/CMakeLists.txt
@@ -1,7 +1,23 @@
 cmake_minimum_required(VERSION 2.6)
 
 if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
+	if(NOT MSVC)
+		set(CLANG_COMPILE_FLAGS_CXX_STD_VER "-std=c++14")
+		add_definitions(-fno-strict-aliasing -fno-short-enums)
+	endif()
 	add_definitions(-D_UNICODE -DUNICODE -D_WIN32_WINNT=0x0600)
+	# @warning on Windows, v8 at this version could emit a big deal of DBG about symbols
+	# so we enable at lease -O2 level optimization
+	if(NOT ${BUILD_TYPE} STREQUAL "release")
+		set(flags "${flags} -O2")
+	endif()
+	
+	include_directories(
+		${PROJECT_SOURCE_DIR}
+		"${PROJECT_SOURCE_DIR}/src"
+		"${PROJECT_SOURCE_DIR}/include"
+		"${PROJECT_SOURCE_DIR}/../"
+	)
 else()
 	include_directories("/usr/local/include/")
 endif()
@@ -16,13 +32,21 @@ add_definitions(
 	-DDISABLE_UNTRUSTED_CODE_MITIGATIONS=1
 )
 
-if(${BUILD_TYPE} STREQUAL "Debug")
-	add_definitions(
-		-DVERIFY_HEAP=1
-		-DOBJECT_PRINT=1
-		-DENABLE_DISASSEMBLER=1
-		-DV8_ENABLE_CHECKS=1
-		-DTRACE_MAPS=1
-		-DENABLE_SLOW_DCHECKS=1
-	)
+if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
+	# always disable debug for MSVC(1925, VS 2019) + v8(6.9), maybe cancel in the future
+	# add_definitions(-DNDEBUG)	
+	if(${BUILD_TYPE} STREQUAL "debug")
+		add_definitions(-DDEBUG)	
+	endif()
+else()
+	if(${BUILD_TYPE} STREQUAL "Debug")
+		add_definitions(
+			-DVERIFY_HEAP=1
+			-DOBJECT_PRINT=1
+			-DENABLE_DISASSEMBLER=1
+			-DV8_ENABLE_CHECKS=1
+			-DTRACE_MAPS=1
+			-DENABLE_SLOW_DCHECKS=1
+		)
+	endif()
 endif()

--- a/v8/test/CMakeLists.txt
+++ b/v8/test/CMakeLists.txt
@@ -3,3 +3,14 @@ cmake_minimum_required(VERSION 2.6)
 set(libs exlib)
 
 include(../../tools/LibraryTest.cmake)
+
+if((${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows") AND (NOT MSVC))
+    add_definitions(
+        -DNOMINMAX
+        -D_CRT_SECURE_NO_WARNINGS
+        -DV8_NO_FAST_TLS
+        -DV8_DEPRECATION_WARNINGS
+        -DENABLE_HANDLE_ZAPPING
+        -D_CONSOLE
+    )
+endif()

--- a/webp/CMakeLists.txt
+++ b/webp/CMakeLists.txt
@@ -1,3 +1,8 @@
 cmake_minimum_required(VERSION 2.6)
 
+if((${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows") AND (NOT MSVC))
+    set(flags "-msse4.1")
+endif()
+add_definitions(-DWEBP_USE_THREAD=1)
+
 include(../tools/Library.cmake)


### PR DESCRIPTION
recover supporting for clang on Windows, better compilation workflow, now you can build fibjs_vender from:

1. naked cmd(extra tools required: standalone LLVM, `make.exe`) - use clang
2. developer command prompt vs 2017 - use msvc

document about this feature would be added as one standalone commit at later commit.